### PR TITLE
Document the correct web-root default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This makes it possible to configure a project with different file layouts; for
 example, either the `drupal/drupal` file layout or the
 `drupal-composer/drupal-project` file layout could be used to set up a project.
 
-If a web-root is not explicitly defined, then it will default to `./`.
+If a web-root is not explicitly defined, then it will default to `.`.
 
 ### Altering Scaffold Files
 


### PR DESCRIPTION
The web root default is set in `::__construct()` in https://github.com/drupal/core-composer-scaffold/edit/8.8.x/ScaffoldOptions.php as `'.'` (dot).

The current `.\` default may give the impression that the web root should end with a slash.