### PR TITLE
Remove 'overwrite' as example in scaffold options

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,6 @@ Sample composer.json for a project that relies on packages that use composer-sca
         "web-root": "./docroot"
       },
       "symlink": true,
-      "overwrite": true,
       "file-mapping": {
         "[web-root]/.htaccess": false,
         "[web-root]/robots.txt": "assets/robots-default.txt"


### PR DESCRIPTION
If I interpret the code correctly, it is not possible to set a default 'overwrite' at scaffold level. `ScaffoldOptions::__construct` does not define an 'overwrite' default. Overwriting is default, but adding it explicitly to an example at scaffold level gives a wrong signal as if other defaults are possible.