### PR TITLE
Core is implicitly allowed to scaffold files

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ web hosting service provider might take its scaffold files from:
 
 Each project allowed to scaffold by the top-level project will be used in turn,
 with projects declared later in the `allowed-packages` list taking precedence
-over the projects named before. The top-level composer.json itself is always
-implicitly allowed to scaffold files, and its scaffold files have highest
+over the projects named before. Drupal core is implicitly allowed and will be
+placed at the top of the list. The top-level composer.json itself is also 
+implicitly allowed to scaffold files, and its scaffold files have highest 
 priority.
 
 ### Defining Project Locations
@@ -230,7 +231,7 @@ The `allowed-packages` configuration setting contains an ordered list of package
 names that will be used during the scaffolding phase.
 ```
 "allowed-packages": [
-  "drupal/core",
+  "example/assets",
 ],
 ```
 ### file-mapping


### PR DESCRIPTION
Mention in the documentation that Drupal core is implicitly allowed to scaffold files. (drupal/legacy-scaffold-assets is too, but imho we should not be totally complete in the docs).

One allowed package example uses `drupal/core` as allowed-package, but that is not a realistic example. Therefore I propose to change it. Not having a realistic example I chose `example/assets`.