### PR TITLE
Fix invalid JSON by removing trailing comma in last properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Examples:
     "append": "assets/robots-append.txt"
   },
   "[web-root]/.htaccess": {
-    "mode": "skip",
+    "mode": "skip"
   }
 }
 ```
@@ -417,7 +417,7 @@ Sample composer.json for drupal/core, with assets placed in a different project:
   "extra": {
     "drupal-scaffold": {
       "allowed-packages": [
-        "drupal/assets",
+        "drupal/assets"
       ]
     }
   }
@@ -477,7 +477,7 @@ Append to robots.txt:
     "drupal-scaffold": {
       "file-mapping": {
         "[web-root]/robots.txt": {
-          "append": "assets/my-robots-additions.txt",
+          "append": "assets/my-robots-additions.txt"
         }
       }
     }


### PR DESCRIPTION
Remove trailing comma for last property in JSON to avoid copy&paste errors.